### PR TITLE
Add 'exclude_unnamed_apps' config parameter

### DIFF
--- a/homeassistant/components/androidtv/media_player.py
+++ b/homeassistant/components/androidtv/media_player.py
@@ -80,6 +80,7 @@ CONF_ADBKEY = "adbkey"
 CONF_ADB_SERVER_IP = "adb_server_ip"
 CONF_ADB_SERVER_PORT = "adb_server_port"
 CONF_APPS = "apps"
+CONF_EXCLUDE_UNNAMED_APPS = "exclude_unnamed_apps"
 CONF_GET_SOURCES = "get_sources"
 CONF_STATE_DETECTION_RULES = "state_detection_rules"
 CONF_TURN_ON_COMMAND = "turn_on_command"
@@ -140,6 +141,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_STATE_DETECTION_RULES, default={}): vol.Schema(
             {cv.string: ha_state_detection_rules_validator(vol.Invalid)}
         ),
+        vol.Optional(CONF_EXCLUDE_UNNAMED_APPS, default=False): cv.boolean,
     }
 )
 
@@ -232,6 +234,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         config[CONF_GET_SOURCES],
         config.get(CONF_TURN_ON_COMMAND),
         config.get(CONF_TURN_OFF_COMMAND),
+        config[CONF_EXCLUDE_UNNAMED_APPS],
     ]
 
     if aftv.DEVICE_CLASS == DEVICE_ANDROIDTV:
@@ -367,7 +370,14 @@ class ADBDevice(MediaPlayerDevice):
     """Representation of an Android TV or Fire TV device."""
 
     def __init__(
-        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+        self,
+        aftv,
+        name,
+        apps,
+        get_sources,
+        turn_on_command,
+        turn_off_command,
+        exclude_unnamed_apps,
     ):
         """Initialize the Android TV / Fire TV device."""
         self.aftv = aftv
@@ -385,6 +395,8 @@ class ADBDevice(MediaPlayerDevice):
 
         self.turn_on_command = turn_on_command
         self.turn_off_command = turn_off_command
+
+        self._exclude_unnamed_apps = exclude_unnamed_apps
 
         # ADB exceptions to catch
         if not self.aftv.adb_server_ip:
@@ -560,11 +572,24 @@ class AndroidTVDevice(ADBDevice):
     """Representation of an Android TV device."""
 
     def __init__(
-        self, aftv, name, apps, get_sources, turn_on_command, turn_off_command
+        self,
+        aftv,
+        name,
+        apps,
+        get_sources,
+        turn_on_command,
+        turn_off_command,
+        exclude_unnamed_apps,
     ):
         """Initialize the Android TV device."""
         super().__init__(
-            aftv, name, apps, get_sources, turn_on_command, turn_off_command
+            aftv,
+            name,
+            apps,
+            get_sources,
+            turn_on_command,
+            turn_off_command,
+            exclude_unnamed_apps,
         )
 
         self._is_volume_muted = None
@@ -603,7 +628,10 @@ class AndroidTVDevice(ADBDevice):
 
         if running_apps:
             sources = [
-                self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
+                self._app_id_to_name.get(
+                    app_id, app_id if not self._exclude_unnamed_apps else None
+                )
+                for app_id in running_apps
             ]
             self._sources = [source for source in sources if source]
         else:
@@ -674,7 +702,10 @@ class FireTVDevice(ADBDevice):
 
         if running_apps:
             sources = [
-                self._app_id_to_name.get(app_id, app_id) for app_id in running_apps
+                self._app_id_to_name.get(
+                    app_id, app_id if not self._exclude_unnamed_apps else None
+                )
+                for app_id in running_apps
             ]
             self._sources = [source for source in sources if source]
         else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!-- 
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
